### PR TITLE
Fixed byte_scores[0] integer overflow

### DIFF
--- a/doit.c
+++ b/doit.c
@@ -127,7 +127,7 @@ void set_cpu(uint8_t cpu)
 bool read_memory_byte(uint8_t *ptr, uint8_t *out_byte)
 {
     uint64_t i = 0;
-    uint8_t byte_scores[0x100] = {0};
+    uint64_t byte_scores[0x100] = {0};
     uint8_t num_cpus = get_nprocs();
 
     // Make a bunch of attempts, as some may fail due to noise


### PR DESCRIPTION
In function read_memory_byte, we should change the type of byte_scores from uint8_t to uint64_t.
uint8_t byte_scores[0x100] = {0}; --> uint64_t byte_scores[0x100] = {0};

Because the byte could really be 0, and if byte_scores[0]>255, it will overflow. For example, if byte_scores[0] is 256, it will overflow, hence byte_scores[0]==0, and will not go into the following branch. As a result, we will miss the real byte 0，specifically when byte_scores[0]%256 is within the interval of [0,ZERO_CONFIDENCE_THRESH].
if (byte_scores[0] > ZERO_CONFIDENCE_THRESH) {
*out_byte = 0;
return true;
}